### PR TITLE
Tweak to hide viewed

### DIFF
--- a/src/app/repos/viewed/page.tsx
+++ b/src/app/repos/viewed/page.tsx
@@ -37,9 +37,7 @@ export default function Page() {
           ? repo.name.toLowerCase().includes(searchQuery.toLowerCase())
           : true;
 
-        const matchesDate = date
-          ? normalizeDate(repo.viewedAt) === normalizeDate(date)
-          : true;
+        const matchesDate = date === repo.viewedAt;
 
         return matchesSearchQuery && matchesDate;
       });
@@ -87,16 +85,3 @@ export default function Page() {
     </main>
   );
 }
-
-// Helper function to normalize date formats
-const normalizeDate = (dateString: string) => {
-  if (/\d{4}-\d{2}-\d{2}/.test(dateString)) {
-    // Date is in YYYY-MM-DD format
-    return dateString;
-  } else if (/\d{2}\/\d{2}\/\d{4}/.test(dateString)) {
-    // Convert DD/MM/YYYY to YYYY-MM-DD
-    const [day, month, year] = dateString.split("/");
-    return `${year}-${month}-${day}`;
-  }
-  return dateString;
-};

--- a/src/app/repos/viewed/page.tsx
+++ b/src/app/repos/viewed/page.tsx
@@ -20,8 +20,13 @@ export default function Page() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const storedRepos = localStorage.getItem("ttViewedRepos");
-      const parsedData = storedRepos ? JSON.parse(storedRepos) : [];
-      setData(parsedData);
+      try {
+        const parsedData = storedRepos ? JSON.parse(storedRepos) : [];
+        setData(parsedData);
+      } catch (error) {
+        console.error("Failed to parse localStorage data:", error);
+        setData([]);
+      }
     }
   }, []);
 

--- a/src/components/Repo.tsx
+++ b/src/components/Repo.tsx
@@ -46,7 +46,7 @@ const Repo: React.FC<RepoProps> = ({ data, show }) => {
     if (!alreadyViewed) {
       const updatedRepo = {
         ...data,
-        viewedAt: new Date().toLocaleDateString(),
+        viewedAt: new Date().toISOString().split("T")[0], // Outputs 'YYYY-MM-DD'
       };
       repos.push(updatedRepo);
 

--- a/src/components/Repo.tsx
+++ b/src/components/Repo.tsx
@@ -74,7 +74,7 @@ const Repo: React.FC<RepoProps> = ({ data, show }) => {
             <p className="text-xl font-semibold text-gray-200">{data.name}</p>
             {viewed && viewedRepo && (
               <p className="text-gray-400 text-sm font-medium text-right">
-                Viewed on: {viewedRepo.viewedAt}
+                Viewed on: {normalizeDate(viewedRepo.viewedAt)}
               </p>
             )}
           </div>
@@ -112,3 +112,14 @@ const Repo: React.FC<RepoProps> = ({ data, show }) => {
 };
 
 export default Repo;
+
+// Helper function to normalize date formats
+const normalizeDate = (dateString: string) => {
+  if (/\d{4}-\d{2}-\d{2}/.test(dateString)) {
+    // Convert DD/MM/YYYY to YYYY-MM-DD
+    const [year, month, day] = dateString.split("-");
+    return `${day}/${month}/${year}`;
+  } else {
+    return dateString;
+  }
+};

--- a/src/components/Repos.tsx
+++ b/src/components/Repos.tsx
@@ -47,6 +47,13 @@ const Repos: React.FC = () => {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
+      const hideViewedStatus = localStorage.getItem("ttHideViewed");
+      setShowViewed(hideViewedStatus === "true" ? false : true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
       localStorage.setItem("ttHideViewed", showViewed ? "false" : "true");
     }
   }, [showViewed]);

--- a/src/components/Repos.tsx
+++ b/src/components/Repos.tsx
@@ -37,12 +37,18 @@ const Repos: React.FC = () => {
 
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [showViewed, setShowViewed] = useState<boolean>(() => {
-    const hideViewed = localStorage.getItem("ttHideViewed");
-    return hideViewed === "true" ? false : true;
+    if (typeof window !== "undefined") {
+      const hideViewed = localStorage.getItem("ttHideViewed");
+      return hideViewed === "true" ? false : true;
+    } else {
+      return true;
+    }
   });
 
   useEffect(() => {
-    localStorage.setItem("ttHideViewed", showViewed ? "false" : "true");
+    if (typeof window !== "undefined") {
+      localStorage.setItem("ttHideViewed", showViewed ? "false" : "true");
+    }
   }, [showViewed]);
 
   useEffect(() => {

--- a/src/components/Repos.tsx
+++ b/src/components/Repos.tsx
@@ -36,7 +36,14 @@ const Repos: React.FC = () => {
   );
 
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const [showViewed, setShowViewed] = useState<boolean>(true);
+  const [showViewed, setShowViewed] = useState<boolean>(() => {
+    const hideViewed = localStorage.getItem("ttHideViewed");
+    return hideViewed === "true" ? false : true;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("ttHideViewed", showViewed ? "false" : "true");
+  }, [showViewed]);
 
   useEffect(() => {
     const fetchData = async () => {


### PR DESCRIPTION
## Description

Amended due to issue handling date on different browsers, which had a side effect of not showing "viewed repos" on the `/repos/viewed` page. Also added the ability to "remember" whether a user had hidden the repos.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules