### PR TITLE
feat(footer): Create a fully responsive footer with copyright symbol and app version

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Navbar from "@/components/Nav";
 import Hero from "@/components/Hero";
 import Repos from "@/components/Repos";
+import Footer from "@/components/Footer";
 
 export default function Home() {
   return (
@@ -8,6 +9,7 @@ export default function Home() {
       <Navbar />
       <Hero />
       <Repos />
+      <Footer />
     </main>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-const Navbar = () => {
+import packageJson from "../../package.json"; // Adjust the path as per your folder structure
+
+const Footer = () => {
   return (
     <div>
       <footer className="footer footer-center bg-base-300 text-base-content p-10">
         <aside>
           <p>
-            Copyright © {new Date().getFullYear()} - All right reserved by
-            TrendTrack - v0.17.0
+            Copyright © {new Date().getFullYear()} - All rights reserved by
+            TrendTrack - v{packageJson.version}
           </p>
         </aside>
       </footer>
@@ -14,4 +16,4 @@ const Navbar = () => {
   );
 };
 
-export default Navbar;
+export default Footer;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+const Navbar = () => {
+  return (
+    <div>
+      <footer className="footer footer-center bg-base-300 text-base-content p-10">
+        <aside>
+          <p>
+            Copyright © {new Date().getFullYear()} - All right reserved by
+            TrendTrack - v0.17.0
+          </p>
+        </aside>
+      </footer>
+    </div>
+  );
+};
+
+export default Navbar;


### PR DESCRIPTION
## Description
Closes #75 
Added a fully responsive footer with copyright and app version as requested in the issue.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable):
![image](https://github.com/user-attachments/assets/134a9ed4-1bce-4ba7-be0d-867b25eb810b)


![image](https://github.com/user-attachments/assets/f67f6a20-ebf9-41bf-a7ab-efa91931eabe)


@Bashamega please review and merge